### PR TITLE
Allows whitespace within parentheses in require() calls

### DIFF
--- a/expose.js
+++ b/expose.js
@@ -47,7 +47,7 @@ function expose(map, origSrc) {
   // ensure that at least one of the require statements we want to replace is in the code
   // before we perform the expensive operation of finding them by creating an AST
   var hasMatchingRequires = keys.some(function (id) {
-    regex = new RegExp('require\\([\'"]' + id + '[\'"]\\)');
+    regex = new RegExp('require\\(\\s*[\'"]' + id + '[\'"]\\s*\\)');
     return regex.test(src)
   });
   if (!hasMatchingRequires) return src;


### PR DESCRIPTION
Before this the only way to write require calls and have them parsed by
exposify was to do `var $ = require('jquery');` - the following would
fail: `var $ = require( 'jquery' );`.

This commit fixes that, and closes an issue opened due to this problem.

Fixes #1
