### PR TITLE
Global scope is not always window.

### DIFF
--- a/expose.js
+++ b/expose.js
@@ -14,7 +14,7 @@ function getReplacements(id, globalVar, requires) {
       var node;
       if (s === id) { 
         node = requires.nodes[index]
-        acc.push({ from: node.range[0], to: node.range[1], id: id, code: '(typeof window !== "undefined" ? global.' + globalVar  + ' : typeof global !== "undefined" ? global.' + globalVar  + ' : null)' });
+        acc.push({ from: node.range[0], to: node.range[1], id: id, code: '(typeof window !== "undefined" ? window.' + globalVar  + ' : typeof global !== "undefined" ? global.' + globalVar  + ' : null)' });
       }
       return acc;
     }, [])


### PR DESCRIPTION
Fixed the issue when using a module in a web worker.

There the `global` object is not `window` but `self`.

See https://github.com/thlorenz/browserify-shim/issues/53
For a discussion.
