### PR TITLE
feat(transform): allow pass options via browserify transform

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,15 +22,14 @@ console.log('jquery version: ', $().jquery);
 #### Building via JavaScript
 
 ```js
-var browserify = require('browserify')
-  , exposify   = require('exposify')
+var browserify = require('browserify');
 
 // configure what we want to expose
-exposify.config = { jquery: '$', three: 'THREE' };
+var exposeConfig = { expose: { jquery: '$', three: 'THREE' } };
 
 browserify()
   .require(require.resolve('./main'), { entry: true })
-  .transform(exposify)
+  .transform(exposeConfig, 'exposify')
   .bundle({ debug: true })
   .pipe(fs.createWriteStream(path.join(__dirname, 'bundle.js'), 'utf8'))
 ```

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var transformify = require('transformify')
   , through = require('through2')
   , expose = require('./expose');
 
-exports = module.exports = 
+exports = module.exports =
 
 /**
  * browserify transform which exposes globals as modules that can be required.
@@ -12,18 +12,24 @@ exports = module.exports =
  * @name exposify
  * @function
  * @param {string} file file whose content is to be transformed
+ * @param {Object} options (exposify config)
  * @return {TransformStream} transform that replaces require statements found in the code with global assigments
  */
-function exposify(file) {
- if (!exports.filePattern.test(file)) return through();  
+function exposify(file, opts) {
+  opts = opts && Object.keys(opts).length ? opts : {
+    filePattern: exports.filePattern,
+    expose: exports.config
+  };
 
- if (typeof exports.config !== 'object') {
-   throw new Error('Please set exposify.config or $EXPOSIFY_CONFIG so it knows what to expose');
- }
+  if (opts.filePattern && !opts.filePattern.test(file)) return through();
 
- var tx = transformify(expose.bind(null, exports.config));
- return tx(file);
-}
+  if (typeof opts.expose !== 'object') {
+   throw new Error('Please pass { expose: { ... } } to transform, set exposify.config or $EXPOSIFY_CONFIG so it knows what to expose');
+  }
+
+  var tx = transformify(expose.bind(null, opts.expose));
+  return tx(file);
+};
 
 
 /**
@@ -31,6 +37,13 @@ function exposify(file) {
  * You need to set this or provide it via the `EXPOSIFY_CONFIG` environment variable.
  *
  * ### Example
+ *
+ *  ```js
+ *  var b = browserify();
+ *
+ *  // setting via transform argument
+ *  b.transform({ expose: { jquery: '$', three: 'THREE' } }, 'exposify');
+ *  ```
  *
  *  ```js
  *  // setting from javascript
@@ -41,9 +54,9 @@ function exposify(file) {
  *  # setting from command line
  *  EXPOSIFY_CONFIG='{ "jquery": "$", "three": "THREE" }' browserify -t exposify ...
  *  ```
- * 
+ *
  * @name exposify::config
- * 
+ *
  */
 exports.config = (function () {
   if (process.env.EXPOSIFY_CONFIG) {
@@ -59,14 +72,14 @@ exports.config = (function () {
 
 /**
  * Regex pattern of files whose content is exposified
- * 
+ *
  * @name exposify::filePattern
  */
 exports.filePattern = /\.js$/;
 
 /**
  * Exposes the expose function that operates on a string
- * 
+ *
  * @name exposify::expose
  */
 exports.expose = expose;

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "detective": "~2.3.0"
   },
   "devDependencies": {
-    "tap": "~0.4.3",
-    "browserify": "~3.20.0"
+    "browserify": "^4.1.10",
+    "tap": "~0.4.3"
   },
   "keywords": [
     "browserify",

--- a/test/transform-config.js
+++ b/test/transform-config.js
@@ -1,0 +1,45 @@
+'use strict';
+
+var browserify     = require('browserify')
+  , vm             = require('vm')
+  , exposify       = require('../');
+
+var test = require('tap').test;
+
+function run(config, file, window, cb) {
+
+  var ctx = { window: window };
+  var fullPath = require.resolve('./fixtures/' + file);
+
+  browserify()
+    .require(fullPath)
+    .transform(config, exposify)
+    .bundle(function (err, res) {
+      if (err) return cb(err);
+      try {
+        var require_ = vm.runInNewContext(res, ctx);
+        cb(null, require_(fullPath));
+      } catch (e) {
+        cb(e);
+      }
+    });
+}
+
+
+function jquery() { return 'jq' }
+
+test('\nproviding jquery:$ and exposifying src with one jquery require', function (t) {
+  var file   = 'jquery-only.js';
+  var window = { $: { jquery: jquery } };
+
+  var config = {
+    expose: { 'jquery': '$' }
+  };
+
+  run(config, file, window, function (err, main) {
+    if (err) { t.fail(err); return t.end(); }
+    t.equal(main(), 'jq', 'exposes $ as jquery');
+
+    t.end();
+  });
+});


### PR DESCRIPTION
This commit adds support for passing the exposify options via

```js
var b = browserify();

// setting via transform argument
b.transform({ expose: { jquery: '$', three: 'THREE' } }, 'exposify');
```

BREAKING CHANGE:

* Requires browserify >= 3.4