### PR TITLE
add ability to pass args thru browserify transform.  closes #5

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,15 +22,14 @@ console.log('jquery version: ', $().jquery);
 #### Building via JavaScript
 
 ```js
-var browserify = require('browserify')
-  , exposify   = require('exposify')
+var browserify = require('browserify');
 
 // configure what we want to expose
-exposify.config = { jquery: '$', three: 'THREE' };
+var exposeConfig = { expose: { jquery: '$', three: 'THREE' } };
 
 browserify()
   .require(require.resolve('./main'), { entry: true })
-  .transform(exposify)
+  .transform(exposeConfig, 'exposify')
   .bundle({ debug: true })
   .pipe(fs.createWriteStream(path.join(__dirname, 'bundle.js'), 'utf8'))
 ```

--- a/index.js
+++ b/index.js
@@ -12,25 +12,36 @@ exports = module.exports =
  * @name exposify
  * @function
  * @param {string} file file whose content is to be transformed
+ * @param {Object} opts (exposify config)
  * @return {TransformStream} transform that replaces require statements found in the code with global assigments
  */
-function exposify(file) {
- if (!exports.filePattern.test(file)) return through();  
+function exposify(file, opts) {
+  opts = opts || {};
+  opts.filePattern = opts.filePattern || exports.filePattern;
+  opts.expose = opts.expose || exports.config;
 
- if (typeof exports.config !== 'object') {
-   throw new Error('Please set exposify.config or $EXPOSIFY_CONFIG so it knows what to expose');
- }
+  if (opts.filePattern && !opts.filePattern.test(file)) return through();
 
- var tx = transformify(expose.bind(null, exports.config));
- return tx(file);
-}
+  if (typeof opts.expose !== 'object') {
+   throw new Error('Please pass { expose: { ... } } to transform, set exposify.config or $EXPOSIFY_CONFIG so it knows what to expose');
+  }
 
+  var tx = transformify(expose.bind(null, opts.expose));
+  return tx(file);
+};
 
 /**
  * The config which is used by exposify to determine which require statemtents to replace and how.
  * You need to set this or provide it via the `EXPOSIFY_CONFIG` environment variable.
  *
  * ### Example
+ *
+ *  ```js
+ *  var b = browserify();
+ *
+ *  // setting via transform argument
+ *  b.transform({ expose: { jquery: '$', three: 'THREE' } }, 'exposify');
+ *  ```
  *
  *  ```js
  *  // setting from javascript

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "tap": "~0.4.3",
-    "browserify": "~3.20.0"
+    "browserify": "~7.0.0"
   },
   "keywords": [
     "browserify",

--- a/test/transform-config.js
+++ b/test/transform-config.js
@@ -1,0 +1,45 @@
+'use strict';
+
+var browserify     = require('browserify')
+  , vm             = require('vm')
+  , exposify       = require('../');
+
+var test = require('tap').test;
+
+function run(config, file, window, cb) {
+
+  var ctx = { window: window };
+  var fullPath = require.resolve('./fixtures/' + file);
+
+  browserify()
+    .require(fullPath)
+    .transform(config, exposify)
+    .bundle(function (err, res) {
+      if (err) return cb(err);
+      try {
+        var require_ = vm.runInNewContext(res, ctx);
+        cb(null, require_(fullPath));
+      } catch (e) {
+        cb(e);
+      }
+    });
+}
+
+
+function jquery() { return 'jq' }
+
+test('\nproviding jquery:$ and exposifying src with one jquery require', function (t) {
+  var file   = 'jquery-only.js';
+  var window = { $: { jquery: jquery } };
+
+  var config = {
+    expose: { 'jquery': '$' }
+  };
+
+  run(config, file, window, function (err, main) {
+    if (err) { t.fail(err); return t.end(); }
+    t.equal(main(), 'jq', 'exposes $ as jquery');
+
+    t.end();
+  });
+});


### PR DESCRIPTION
This is basically @Nikku's PR #4 with whitespace changes removed, and updates to Browserify 7.0.0 for testing.

I made a small modification to his PR [here](https://github.com/boneskull/exposify/compare/thlorenz:master...boneskull:issue/4?expand=1#diff-168726dbe96b3ce427e7fedce31bb0bcR19) because somewhere between 4.x and 7.x the options object *always* contains a `_flags` variable.  So instead of using `EXPOSIFY_CONFIG`, `exposify.config` or `transform()` parameters, we always use the `transform()` parameters and "fill in the blanks" if our config is missing.  This *should* not break compatibility with 4.x/5.x/6.x, but of course I haven't tested against all versions.