### PR TITLE
Upgrade to detective 4.0.0 for better ES6 compatibility.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "homepage": "https://github.com/thlorenz/exposify",
   "dependencies": {
-    "detective": "~2.3.0",
+    "detective": "~4.0.0",
     "has-require": "~1.1.0",
     "through2": "~0.4.0",
     "transformify": "~0.1.1"


### PR DESCRIPTION
The existing version (~2.3.0) of detective breaks when it encounters ES6 artifacts like yield*. Upgrade to 4.0.0 fixes them (at least the ones I have). All tests pass.