### PR TITLE
Filter out non-literal nodes from detective

### DIFF
--- a/expose.js
+++ b/expose.js
@@ -10,11 +10,18 @@ function rangeComparator(a, b) {
 function getReplacements(id, globalVar, requires) {
   if (!~requires.strings.indexOf(id)) return [];
 
+  // We only care about string nodes like (require('foo')) here. If you include
+  // non-literal nodes this function will return mismatched requires, since it
+  // assumes requires.strings[0] corresponds to requires.nodes[0]
+  var stringNodes = requires.nodes.filter(function(node) {
+    return (node.arguments[0].type === 'Literal');
+  });
+
   var ranges = requires.strings
     .reduce(function (acc, s, index) {
       var node;
       if (s === id) { 
-        node = requires.nodes[index]
+        node = stringNodes[index]
         acc.push({ from: node.range[0], to: node.range[1], id: id, code: '(window.' + globalVar  + ')' });
       }
       return acc;

--- a/test/fixtures/jquery-plus-non-literals.js
+++ b/test/fixtures/jquery-plus-non-literals.js
@@ -1,0 +1,9 @@
+'use strict';
+
+var foo = require(foo),
+    $ = require( 'jquery' ),
+    bar = require( bar );
+
+var go = module.exports = function () {
+  return $.jquery();
+};

--- a/test/jquery-plus-non-literals.js
+++ b/test/jquery-plus-non-literals.js
@@ -1,0 +1,20 @@
+'use strict';
+/*jshint asi: true */
+
+var test = require('tap').test
+  , run  = require('./util/run')
+
+function jquery() { return 'jq' }
+
+test('\nproviding jquery:$ and requiring variable (non-literal) named paths', function (t) {
+  var file   = 'jquery-plus-non-literals.js';
+  var map    = { 'jquery': '$' };
+  var window = { $: { jquery: jquery } };
+
+  run(map, file, window, {ignoreMissing: true}, function (err, main) {
+    if (err) { t.fail(err); return t.end(); }
+    t.equal(main(), 'jq', 'exposes $ as jquery');
+
+    t.end();
+  });
+})

--- a/test/util/run.js
+++ b/test/util/run.js
@@ -18,7 +18,9 @@ module.exports = function run(map, file, window, cb) {
     cb = arguments[4];
   }
 
-  // If ignoreMissing is true, set ctx.require to a no-op
+  // If ignoreMissing is true, set ctx.require to a no-op. This needed for the
+  // jquery-plus-non-literals test, as it has require statements that don't get
+  // converted with browserify-shim.
   if ('ignoreMissing' in opts) {
     ctx.require = function() {};
   }

--- a/test/util/run.js
+++ b/test/util/run.js
@@ -10,7 +10,20 @@ module.exports = function run(map, file, window, cb) {
   var ctx = { window: window };
   var fullPath = require.resolve('../fixtures/' + file);
 
-  browserify()
+  // If five arguments are provided, fourth one is an object for browserify
+  // options.
+  var opts = {};
+  if (arguments.length === 5) {
+    opts = cb;
+    cb = arguments[4];
+  }
+
+  // If ignoreMissing is true, set ctx.require to a no-op
+  if ('ignoreMissing' in opts) {
+    ctx.require = function() {};
+  }
+
+  browserify(opts)
     .require(fullPath)
     .transform(exposify)
     .bundle(function (err, res) {


### PR DESCRIPTION
Hello! I've found a bug with exposify that I've fixed in the following branch. Basically, if you had code like

````
require(foo)
require('underscore')
````

and you were mapping `underscore` to `global._`, instead of behaving as expected, it would replace the `foo` with `global._` instead of the `require('underscore')` line.

This is because the detective library returns all require statements, including ones like `require(foo)`. But `exposify` assumes all the nodes returned are statements like `require('string')`.

I hope that makes sense, I added a test case for the bug, which now passes.

Thanks.