### PR TITLE
Use replace-requires to perform replacements

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ Or use [browserify-shim](https://github.com/thlorenz/browserify-shim) which can 
 <div class="description">
 <p>The config which is used by exposify to determine which require statemtents to replace and how.
 You need to set this or provide it via the <code>EXPOSIFY_CONFIG</code> environment variable.</p>
+<pre><code class="lang-js"> var b = browserify();
+// setting via transform argument
+b.transform('exposify', { expose: { jquery: '$', three: 'THREE' } });</code></pre>
 <pre><code class="lang-js"> // setting from javascript
 exposify.config = { jquery: '$', three: 'THREE' };</code></pre>
 <pre><code class="lang-sh"> # setting from command line
@@ -86,7 +89,7 @@ EXPOSIFY_CONFIG='{ &quot;jquery&quot;: &quot;$&quot;, &quot;three&quot;: &quot;T
 <li>
 <a href="https://github.com/thlorenz/exposify/blob/master/index.js">index.js</a>
 <span>, </span>
-<a href="https://github.com/thlorenz/exposify/blob/master/index.js#L29">lineno 29</a>
+<a href="https://github.com/thlorenz/exposify/blob/master/index.js#L33">lineno 33</a>
 </li>
 </ul></dd>
 </dl>
@@ -104,7 +107,7 @@ EXPOSIFY_CONFIG='{ &quot;jquery&quot;: &quot;$&quot;, &quot;three&quot;: &quot;T
 <li>
 <a href="https://github.com/thlorenz/exposify/blob/master/index.js">index.js</a>
 <span>, </span>
-<a href="https://github.com/thlorenz/exposify/blob/master/index.js#L67">lineno 67</a>
+<a href="https://github.com/thlorenz/exposify/blob/master/index.js#L78">lineno 78</a>
 </li>
 </ul></dd>
 </dl>
@@ -122,7 +125,7 @@ EXPOSIFY_CONFIG='{ &quot;jquery&quot;: &quot;$&quot;, &quot;three&quot;: &quot;T
 <li>
 <a href="https://github.com/thlorenz/exposify/blob/master/index.js">index.js</a>
 <span>, </span>
-<a href="https://github.com/thlorenz/exposify/blob/master/index.js#L60">lineno 60</a>
+<a href="https://github.com/thlorenz/exposify/blob/master/index.js#L71">lineno 71</a>
 </li>
 </ul></dd>
 </dl>
@@ -130,7 +133,7 @@ EXPOSIFY_CONFIG='{ &quot;jquery&quot;: &quot;$&quot;, &quot;three&quot;: &quot;T
 </dl>
 <dl>
 <dt>
-<h4 class="name" id="exposify"><span class="type-signature"></span>exposify<span class="signature">(file)</span><span class="type-signature"> &rarr; {TransformStream}</span></h4>
+<h4 class="name" id="exposify"><span class="type-signature"></span>exposify<span class="signature">(file, <span class="optional">opts</span>)</span><span class="type-signature"> &rarr; {TransformStream}</span></h4>
 </dt>
 <dd>
 <div class="description">
@@ -142,6 +145,7 @@ EXPOSIFY_CONFIG='{ &quot;jquery&quot;: &quot;$&quot;, &quot;three&quot;: &quot;T
 <tr>
 <th>Name</th>
 <th>Type</th>
+<th>Argument</th>
 <th class="last">Description</th>
 </tr>
 </thead>
@@ -151,7 +155,19 @@ EXPOSIFY_CONFIG='{ &quot;jquery&quot;: &quot;$&quot;, &quot;three&quot;: &quot;T
 <td class="type">
 <span class="param-type">string</span>
 </td>
+<td class="attributes">
+</td>
 <td class="description last"><p>file whose content is to be transformed</p></td>
+</tr>
+<tr>
+<td class="name"><code>opts</code></td>
+<td class="type">
+<span class="param-type">Object</span>
+</td>
+<td class="attributes">
+&lt;optional><br>
+</td>
+<td class="description last"><p>(exposify config), defaults to exposify.config or $EXPOSIFY_CONFIG</p></td>
 </tr>
 </tbody>
 </table>

--- a/expose.js
+++ b/expose.js
@@ -1,84 +1,11 @@
 'use strict';
 
-var detective = require('detective')
-  , hasRequire = require('has-require');
+var mapObject = require('map-obj');
+var replaceRequires = require('replace-requires');
 
-function rangeComparator(a, b) {
-  return a.from > b.from ? 1 : -1;
-}
-
-function getReplacements(id, globalVar, requires) {
-  if (!~requires.strings.indexOf(id)) return [];
-
-  // We only care about string nodes like (require('foo')) here. If you include
-  // non-literal nodes this function will return mismatched requires, since it
-  // assumes requires.strings[0] corresponds to requires.nodes[0]
-  var stringNodes = requires.nodes.filter(function(node) {
-    return (node.arguments[0].type === 'Literal');
-  });
-
-  var ranges = requires.strings
-    .reduce(function (acc, s, index) {
-      var node;
-      if (s === id) { 
-        node = stringNodes[index]
-        acc.push({ from: node.range[0], to: node.range[1], id: id, code: '(window.' + globalVar  + ')' });
-      }
-      return acc;
-    }, [])
-
-  return ranges;
-}
-
-function inspect(obj, depth) {
-  console.error(require('util').inspect(obj, false, depth || 5, true));
-}
-
-var go = module.exports = 
-
-/**
- * Replaces each require statement for ids found in the map with an assignment to the global value.
- *
- * @name expose
- * @private
- * @function
- * @param {Object.<string, string>} map maps module names to the global under which they are actually exposed
- * @param {string} origSrc the original source
- * @return {string} source with globals exposed
- */
-function expose(map, origSrc) {
-  var regex, keys, id;
-  var src = origSrc;
-
-  keys = Object.keys(map);
-
-  // ensure that at least one of the require statements we want to replace is in the code
-  // before we perform the expensive operation of finding them by creating an AST
-  var requireChecker = new hasRequire.Checker(src);
-  var hasMatchingRequires = keys.some(requireChecker.has, requireChecker);
-  if (!hasMatchingRequires) return src;
-
-  var requires = detective.find(src, { nodes: true, parse: { range: true } });
-  if (!requires.strings.length) return src;
-
-  var replacements = keys
-    .reduce(function (acc, id) {
-      var r = getReplacements(id, map[id], requires);
-      return acc.concat(r);
-    }, [])
-    .sort(rangeComparator);
-
-  var offset = 0;
-  return replacements
-    .reduce(function(acc, replacement) {
-      var from = replacement.from + offset
-        , to   = replacement.to + offset
-        , code = replacement.code;
-
-      // all ranges will be invalidated since we are changing the code
-      // therefore keep track of the offset to adjust them in case we replace multiple requires
-      var diff = code.length - (to - from);
-      offset += diff;
-      return acc.slice(0, from) + code + acc.slice(to);
-    }, src);
+module.exports = function expose (replacements, code) {
+  replacements = mapObject(replacements, function (id, globalVar) {
+    return [id, '(window.' + globalVar + ')']
+  })
+  return replaceRequires(code, replacements)
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
   "dependencies": {
     "detective": "~4.0.0",
     "has-require": "~1.1.0",
+    "map-obj": "~1.0.1",
+    "replace-requires": "~1.0.1",
     "through2": "~0.4.0",
     "transformify": "~0.1.1"
   },


### PR DESCRIPTION
This removes the major of the library code so I definitely figured you'd want to review. No changes to functionality, including regexing the code to potentially avoid an AST parse. Avoids some misdirection with requires.strings.

Coming full circle on https://github.com/thlorenz/proxyquireify/issues/20#issuecomment-59933424 :smile: 

I'd duplicated some exposify/proxyquireify stuff in proxyquire-universal, which is basically empty now:

https://github.com/bendrucker/proxyquire-universal/blob/master/transform.js