### PR TITLE
Remove _ array from expose config

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,11 @@ function exposify(file, opts) {
    throw new Error('Please pass { expose: { ... } } to transform, set exposify.config or $EXPOSIFY_CONFIG so exposify knows what to expose');
   }
 
+  // using transform options will pass non-option arguments as array on _
+  if (Array.isArray(opts.expose._)) {
+    delete opts.expose._
+  }
+
   var tx = transformify(expose.bind(null, opts.expose));
   return tx(file);
 };


### PR DESCRIPTION
Browserify passes non-option args under _:

```sh
browserify -t [ exposify [ --foo=bar baz ] ]
#=> {_: ['baz'], foo: 'bar'}
```

If you actually wanted to shim lodash, you'd have to use JSON or the api